### PR TITLE
Make sure that the rows returned are not empty

### DIFF
--- a/muc_lookup.py
+++ b/muc_lookup.py
@@ -116,6 +116,8 @@ def lookup_supersedence(kb):
         headers=default_headers,
     )
     rows = browser.get_current_page().find(id="ctl00_catalogBody_updateMatches")
+    if rows is None:
+        return []
     updates = rows.find_all(
         "a", {"onclick": re.compile(r"goToDetails\(\"[a-zA-Z0-9-]+\"\)")}
     )


### PR DESCRIPTION
If the rows object is None, you cannot iterate over the object. Added check to make sure rows exist/has data, if not, return empty list.