### PR TITLE
feat: support Windows10, Windows Server 2022 21H2

### DIFF
--- a/validation/10_21H2_x64_pro_systeminfo.txt
+++ b/validation/10_21H2_x64_pro_systeminfo.txt
@@ -1,0 +1,50 @@
+Host Name:                 DESKTOP
+OS Name:                   Microsoft Windows 10 Pro
+OS Version:                10.0.19044 N/A Build 19044
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Member Workstation
+OS Build Type:             Multiprocessor Free
+Registered Owner:          Windows User
+Registered Organization:
+Product ID:                00000-00000-00000-AA000
+Original Install Date:     2022/04/13, 12:25:41
+System Boot Time:          2022/06/06, 16:43:45
+System Manufacturer:       HP
+System Model:              HP EliteBook 830 G7 Notebook PC
+System Type:               x64-based PC
+Processor(s):              1 Processor(s) Installed.
+                           [01]: Intel64 Family 6 Model 142 Stepping 12 GenuineIntel ~1803 Mhz
+BIOS Version:              HP S70 Ver. 01.05.00, 2021/04/26
+Windows Directory:         C:\WINDOWS
+System Directory:          C:\WINDOWS\system32
+Boot Device:               \Device\HarddiskVolume2
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (UTC-08:00) Pacific Time (US & Canada)
+Total Physical Memory:     15,709 MB
+Available Physical Memory: 12,347 MB
+Virtual Memory: Max Size:  18,141 MB
+Virtual Memory: Available: 14,375 MB
+Virtual Memory: In Use:    3,766 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    WORKGROUP
+Logon Server:              \\DESKTOP
+Hotfix(s):                 7 Hotfix(s) Installed.
+                           [01]: KB5012117
+                           [02]: KB4562830
+                           [03]: KB5003791
+                           [04]: KB5007401
+                           [05]: KB5012599
+                           [06]: KB5011651
+                           [07]: KB5005699
+Network Card(s):           1 NIC(s) Installed.
+                           [01]: Intel(R) Wi-Fi 6 AX201 160MHz
+                                 Connection Name: Wi-Fi
+                                 DHCP Enabled:    Yes
+                                 DHCP Server:     192.168.0.1
+                                 IP address(es)
+                                 [01]: 192.168.0.205
+Hyper-V Requirements:      VM Monitor Mode Extensions: Yes
+                           Virtualization Enabled In Firmware: Yes
+                           Second Level Address Translation: Yes
+                           Data Execution Prevention Available: Yes

--- a/wes.py
+++ b/wes.py
@@ -107,7 +107,9 @@ buildnumbers = OrderedDict([
     (19041, 2004),
     (19042, '20H2'),
     (19043, '21H1'),
-    (22000, '21H2') # Windows 11
+    (19044, '21H2'), # Windows 10
+    (20348, '21H2'), # Windows Server 2022
+    (22000, '21H2')  # Windows 11
 ])
 
 


### PR DESCRIPTION
21H2 seems to have different build numbers for Windows 10, 11, and Windows Server 2022.

### before
```console
$ ./wes.py systeminfo.txt
Windows Exploit Suggester 1.02 ( https://github.com/bitsadmin/wesng/ )
[+] Parsing systeminfo output
[+] Operating System
    - Name: Windows 10 Version 21H1 for x64-based Systems
    - Generation: 10
    - Build: 19044
    - Version: 21H1
    - Architecture: x64-based
...
```

### after
```console
$ ./wes.py systeminfo.txt
Windows Exploit Suggester 1.02 ( https://github.com/bitsadmin/wesng/ )
[+] Parsing systeminfo output
[+] Operating System
    - Name: Windows 10 Version 21H2 for x64-based Systems
    - Generation: 10
    - Build: 19044
    - Version: 21H2
    - Architecture: x64-based
...
```

The following Build Number was used as a reference.
- Windows 10 21H2 build number 19044
![image](https://user-images.githubusercontent.com/16035056/172496413-f2194752-d54f-463a-b1a3-eafe3415026f.png)
https://docs.microsoft.com/en-us/windows/release-health/release-information

- Windows Server 2022 21H2 build number 20348
![image](https://user-images.githubusercontent.com/16035056/172495794-89304c9b-2342-41dc-9e41-8f16e36a57b6.png)
https://docs.microsoft.com/en-us/windows-server/get-started/windows-server-release-info