### PR TITLE
Add chardet in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     py_modules=['wes', 'muc_lookup'],
     python_requires='>=3.4, >=2.7',
-    install_requires=[chardet],
+    install_requires=['chardet'],
     package_data={
         'definitions': ['definitions.zip']
     },

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     py_modules=['wes', 'muc_lookup'],
     python_requires='>=3.4, >=2.7',
-    install_requires=[],
+    install_requires=[chardet],
     package_data={
         'definitions': ['definitions.zip']
     },


### PR DESCRIPTION
Hi,

Just a little PR to add chardet because of an error if I install it with pipx : 

```
WARNING:root:chardet module not installed. In case of encoding errors, install chardet using: pip3 install chardet
```
It's not really an issue, but it's fine to have a tool without error on each commands.

Thanks :)
