### PR TITLE
Added support for Win 7 Embedded

### DIFF
--- a/wes.py
+++ b/wes.py
@@ -557,7 +557,7 @@ def determine_product(systeminfo):
     servicepack = systeminfo_matches[4]
 
     # OS Name
-    win_matches = re.findall(r'.*?Microsoft[\(R\)]{0,3} Windows[\(R\)?]{0,3} ?(Serverr? )?(\d+\.?\d?( R2)?|XP|VistaT).*', systeminfo, re.MULTILINE | re.IGNORECASE)
+    win_matches = re.findall(r'.*?Microsoft[\(R\)]{0,3} Windows[\(R\)?]{0,3} ?(Serverr? )?(\d+\.?\d?( R2)?|XP|VistaT|Embedded Standard).*', systeminfo, re.MULTILINE | re.IGNORECASE)
     if len(win_matches) == 0:
         raise WesException('Not able to detect OS name based on provided input file')
     win = win_matches[0][1]
@@ -605,7 +605,7 @@ def determine_product(systeminfo):
             productfilter += ' %s Edition' % arch
         if servicepack:
             productfilter += ' Service Pack %s' % servicepack
-    elif win == '7':
+    elif win == '7' or win == 'Embedded Standard':
         productfilter = 'Windows %s for %s Systems' % (win, arch)
         if servicepack:
             productfilter += ' Service Pack %s' % servicepack

--- a/wes.py
+++ b/wes.py
@@ -606,7 +606,7 @@ def determine_product(systeminfo):
         if servicepack:
             productfilter += ' Service Pack %s' % servicepack
     elif win == '7' or win == 'Embedded Standard':
-        productfilter = 'Windows %s for %s Systems' % (win, arch)
+        productfilter = 'Windows 7 for %s Systems' % (arch)
         if servicepack:
             productfilter += ' Service Pack %s' % servicepack
     elif win == '8':


### PR DESCRIPTION
My systeminfo output was not recognized:

```text
...
OS Name:                   Microsoft Windows Embedded Standard 
OS Version:                6.1.7601 Service Pack 1 Build 7601
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Standalone Workstation
OS Build Type:             Multiprocessor Free
...
System Type:               X86-based PC
...
```

It is clearly [Windows 7 Embedded 32bit](https://learn.microsoft.com/en-us/lifecycle/products/windows-embedded-standard-7). I adjusted the regex and the if statement. 

Edit: There are [more](https://learn.microsoft.com/en-us/lifecycle/products/?terms=embedded%207) versions than "standard". I do not have systeminfo output files from those. So for now, this will only work for "standard". I'll see if I can find ISOs for all versions. Also there would be 8/8.1 Embedded which would also need to be matched onto 8/8.1. 