### PR TITLE
Remove unused import in muc_lookup.py (F401)

### DIFF
--- a/muc_lookup.py
+++ b/muc_lookup.py
@@ -13,7 +13,7 @@
 
 from __future__ import print_function
 
-import sys, os
+import sys
 import logging
 import re
 


### PR DESCRIPTION
Remove unused  import flagged by Ruff rule F401.